### PR TITLE
About Us and Contact links available after clicking the Documentation button

### DIFF
--- a/src/app/documentation/documentation.component.html
+++ b/src/app/documentation/documentation.component.html
@@ -2,6 +2,8 @@
     <mat-toolbar-row>
   
       <button mat-button (click)="goHome()">BlueXolo</button>
+      <button mat-button (click)="goInformation()">About Us</button>
+      <button mat-button (click)="goFooter()">Contact</button>
       <button mat-button (click)="goDocumentation()">Documentation</button>
   
       <span class="spacer"></span>

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -293,6 +293,14 @@ export class DocumentationComponent implements OnInit {
     this.router.navigate(['/']);
   }
 
+  goInformation() {
+    window.location.replace('#information');
+  }
+
+  goFooter() {
+    window.location.replace('#footer');
+  }
+
   goDocumentation() {
     this.router.navigate(['/documentation']);
   }


### PR DESCRIPTION
Now when the user clicks on the Documentation button the About Us and Contact buttons still available.
![updated_behavior_history-3](https://user-images.githubusercontent.com/56317975/74997741-84ad7880-541c-11ea-9123-7de98c9b089a.png)
