### PR TITLE
About Us And Contact Links Added

### DIFF
--- a/src/app/documentation/documentation.component.html
+++ b/src/app/documentation/documentation.component.html
@@ -2,6 +2,8 @@
     <mat-toolbar-row>
   
       <button mat-button (click)="goHome()">BlueXolo</button>
+      <button mat-button (click)="goInformation()">About Us</button>
+      <button mat-button (click)="goFooter()">Contact</button>
       <button mat-button (click)="goDocumentation()">Documentation</button>
   
       <span class="spacer"></span>

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -293,6 +293,14 @@ export class DocumentationComponent implements OnInit {
     this.router.navigate(['/']);
   }
 
+  goInformation() {
+    window.location.replace('#information');
+  }
+
+  goFooter() {
+    window.location.replace('#footer');
+  }
+
   goDocumentation() {
     this.router.navigate(['/documentation']);
   }


### PR DESCRIPTION
Now when the user clicks on the Documentation button the "About Us" and "Contact" buttons still available.

![updated_behavior_history-3](https://user-images.githubusercontent.com/56317975/75216172-c1e57380-5758-11ea-8102-c227062f81f6.png)
