### PR TITLE
#5 Update Contact link to redirect to Blue Xolo Google Group

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,7 +4,7 @@
   
       <button mat-button (click)="goHome()">{{title}}</button>
       <button class="button-items" mat-button (click)="goInformation()">About Us</button>
-      <button class="button-items" mat-button (click)="goFooter()">Contact</button>
+      <button class="button-items" mat-button (click)="goFooter()">Quick Links</button>
       <button mat-button (click)="goDocumentation()">Documentation</button>
   
       <span class="spacer"></span>

--- a/src/app/documentation/documentation.component.html
+++ b/src/app/documentation/documentation.component.html
@@ -3,7 +3,7 @@
   
       <button mat-button (click)="goHome()">BlueXolo</button>
       <button mat-button (click)="goInformation()">About Us</button>
-      <button mat-button (click)="goFooter()">Contact</button>
+      <button mat-button (click)="goFooter()">Quick Links</button>
       <button mat-button (click)="goDocumentation()">Documentation</button>
   
       <span class="spacer"></span>


### PR DESCRIPTION
I´ve changed the "Contact" button to "Quick Links". This button redirects to the footer of the page, there you can see the Quick Links, that does make sense this change. 